### PR TITLE
feat(examples): enable tracing on embed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     env:
+      RUSTFLAGS: --cfg hyper_unstable_tracing
       RUSTDOCFLAGS: -Dwarnings --cfg docsrs
     steps:
       - uses: actions/checkout@v4

--- a/examples/static-files/embed/Cargo.toml
+++ b/examples/static-files/embed/Cargo.toml
@@ -4,8 +4,19 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
+[features]
+tracing = [
+  "dep:hyper",
+  "dep:tracing",
+  "dep:tracing-subscriber"
+]
+
 [dependencies]
 viz = { workspace = true, features = ["embed"] }
 
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 rust-embed.workspace = true
+
+hyper = { workspace = true, features = ["tracing"], optional = true }
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }

--- a/examples/static-files/embed/src/main.rs
+++ b/examples/static-files/embed/src/main.rs
@@ -10,6 +10,9 @@ struct Asset;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    #[cfg(feature = "tracing")]
+    tracing_subscriber::fmt::init();
+
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = TcpListener::bind(addr).await?;
     println!("listening on http://{addr}");


### PR DESCRIPTION
Related #104 

```console
USTFLAGS="--cfg hyper_unstable_tracing" RUST_LOG='trace,hyper=trace' cargo run --bin  embed --features tracing
```

@Baiyuetribe Can you try this branch? Collect logs to pinpoint problems.