### PR TITLE
Fix template examples

### DIFF
--- a/examples/templates/askama/src/main.rs
+++ b/examples/templates/askama/src/main.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use askama::Template;
 use tokio::net::TcpListener;
-use viz::{serve, BytesMut, Error, Request, Response, ResponseExt, Result, Router};
+use viz::{serve, Error, Request, Response, ResponseExt, Result, Router};
 
 #[derive(Template)]
 #[template(path = "hello.html")]
@@ -13,15 +13,11 @@ struct HelloTemplate<'a> {
 }
 
 async fn index(_: Request) -> Result<Response> {
-    let mut buf = BytesMut::with_capacity(512);
-    buf.extend(
-        HelloTemplate { name: "world" }
-            .render()
-            .map_err(Error::boxed)?
-            .as_bytes(),
-    );
+    let body = HelloTemplate { name: "world" }
+        .render()
+        .map_err(Error::boxed)?;
 
-    Ok(Response::html(buf.freeze()))
+    Ok(Response::html(body))
 }
 
 #[tokio::main]

--- a/examples/templates/markup/Cargo.toml
+++ b/examples/templates/markup/Cargo.toml
@@ -10,4 +10,3 @@ viz.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 markup = "0.15"
-v_htmlescape = "0.15"

--- a/examples/templates/markup/src/main.rs
+++ b/examples/templates/markup/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
 
 markup::define! {
     TodosTemplate<'a>(items: Vec<Todo<'a>>) {
-        {markup::doctype()}
+        @markup::doctype()
         html {
             head {
                 title { "Todos" }
@@ -55,8 +55,8 @@ markup::define! {
                     tr { th { "ID" } th { "Content" } }
                     @for item in items {
                         tr {
-                            td { {item.id} }
-                            td { {markup::raw(v_htmlescape::escape(item.content).to_string())} }
+                            td { @item.id }
+                            td { @item.content }
                         }
                     }
                 }

--- a/examples/templates/markup/src/main.rs
+++ b/examples/templates/markup/src/main.rs
@@ -4,7 +4,7 @@
 
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
-use viz::{serve, BytesMut, Request, Response, ResponseExt, Result, Router};
+use viz::{serve, Request, Response, ResponseExt, Result, Router};
 
 pub struct Todo<'a> {
     id: u64,
@@ -22,10 +22,9 @@ async fn index(_: Request) -> Result<Response> {
             content: "Learn English",
         },
     ];
-    let mut buf = BytesMut::with_capacity(512);
-    buf.extend(TodosTemplate { items }.to_string().as_bytes());
+    let body = TodosTemplate { items }.to_string();
 
-    Ok(Response::html(buf.freeze()))
+    Ok(Response::html(body))
 }
 
 #[tokio::main]

--- a/examples/templates/minijinja/src/main.rs
+++ b/examples/templates/minijinja/src/main.rs
@@ -7,7 +7,7 @@ use minijinja::{context, path_loader, Environment};
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use tokio::net::TcpListener;
-use viz::{serve, BytesMut, Error, Request, Response, ResponseExt, Result, Router};
+use viz::{serve, Error, Request, Response, ResponseExt, Result, Router};
 
 static TPLS: Lazy<Environment> = Lazy::new(|| {
     let dir = env::var("CARGO_MANIFEST_DIR").map(PathBuf::from).unwrap();
@@ -23,28 +23,25 @@ struct User<'a> {
 }
 
 async fn index(_: Request) -> Result<Response> {
-    let mut buf = BytesMut::with_capacity(512);
-    buf.extend(
-        TPLS.get_template("index.html")
-            .map_err(Error::boxed)?
-            .render(context! {
-                title => "Viz.rs",
-                users => &vec![
-                    User {
-                        url: "https://github.com/rust-lang",
-                        username: "rust-lang",
-                    },
-                    User {
-                        url: "https://github.com/viz-rs",
-                        username: "viz-rs",
-                    },
-                ],
-            })
-            .map_err(Error::boxed)?
-            .as_bytes(),
-    );
+    let body = TPLS
+        .get_template("index.html")
+        .map_err(Error::boxed)?
+        .render(context! {
+            title => "Viz.rs",
+            users => &vec![
+                User {
+                    url: "https://github.com/rust-lang",
+                    username: "rust-lang",
+                },
+                User {
+                    url: "https://github.com/viz-rs",
+                    username: "viz-rs",
+                },
+            ],
+        })
+        .map_err(Error::boxed)?;
 
-    Ok(Response::html(buf.freeze()))
+    Ok(Response::html(body))
 }
 
 #[tokio::main]

--- a/examples/templates/minijinja/templates/index.html
+++ b/examples/templates/minijinja/templates/index.html
@@ -3,7 +3,7 @@
 {% block body %}
 <ul>
 {% for user in users %}
-  <li><a href="{{ user.url | safe }}">{{ user.username }}</a></li>
+  <li><a href="{{ user.url }}">{{ user.username }}</a></li>
 {% endfor %}
 </ul>
 {% endblock %}

--- a/examples/templates/tera/src/main.rs
+++ b/examples/templates/tera/src/main.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 use serde::Serialize;
 use tera::{Context, Tera};
 use tokio::net::TcpListener;
-use viz::{serve, BytesMut, Error, Request, Response, ResponseExt, Result, Router};
+use viz::{serve, Error, Request, Response, ResponseExt, Result, Router};
 
 static TPLS: Lazy<Tera> =
     Lazy::new(|| Tera::new("examples/templates/tera/templates/**/*").unwrap());
@@ -33,14 +33,9 @@ async fn index(_: Request) -> Result<Response> {
             },
         ],
     );
-    let mut buf = BytesMut::with_capacity(512);
-    buf.extend(
-        TPLS.render("index.html", &ctx)
-            .map_err(Error::boxed)?
-            .as_bytes(),
-    );
+    let body = TPLS.render("index.html", &ctx).map_err(Error::boxed)?;
 
-    Ok(Response::html(buf.freeze()))
+    Ok(Response::html(body))
 }
 
 #[tokio::main]

--- a/examples/templates/tera/templates/index.html
+++ b/examples/templates/tera/templates/index.html
@@ -1,6 +1,6 @@
 <title>{% block title %}{% endblock title %}</title>
 <ul>
 {% for user in users -%}
-  <li><a href="{{ user.url | safe }}">{{ user.username }}</a></li>
+  <li><a href="{{ user.url }}">{{ user.username }}</a></li>
 {%- endfor %}
 </ul>


### PR DESCRIPTION
* Use canonical syntax to print items
* No need to use another HTML escaper
* Don't convert to bytes by manually copying
* Don't use `| safe` in examples